### PR TITLE
Small formatting and spelling fixes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To install PlantUML run this wget process:
     -O /sbin/plantuml.jar
 
 PlantumUML requires java:
+
     sudo apt-get install openjdk-7-jre
 
 We use [Inkscape](http://inkscape.org/ "Inkscape") to edit SVG images
@@ -122,18 +123,21 @@ Checks for structural changes:
 Testing the change locally:
 
 1. Download the branch:
-   git review -d <gerrit-id>
+
+        git review -d <gerrit-id>
 
 2. Check that it's based on the current tip of the master branch, look
    for "origin/master" next to commit hash in the output of:
-   git log --graph --decorate
+
+        git log --graph --decorate
 
 3. If it's not, check if it can be rebased onto master cleanly:
-   git rebase --onto master HEAD^
+
+        git rebase --onto master HEAD^
 
 4. Build HTML and PDF versions as described above. If rebase was
    necessary, build from the rebased version: you want to see what the
-   result of the merge into master will look like
+   result of the merge into master will look like.
 
 5. Check that the count of warnings reported by 'make pdf' hasn't
    increased relative to master.

--- a/pages/file-ref/0000-intro.rst
+++ b/pages/file-ref/0000-intro.rst
@@ -19,7 +19,7 @@ for select configuration files that Fuel uses.
    you will receive a warning
    that some attributes were modified from the outside.
    Some features may become inaccessible
-   from the  UI after you do this.
+   from the UI after you do this.
 
 These pages are under development;
 the information presented here has been reviewed

--- a/pages/frequently-asked-questions/0300-other-questions.rst
+++ b/pages/frequently-asked-questions/0300-other-questions.rst
@@ -31,7 +31,7 @@ Other Questions
    for OpenStack packages.
 
 
-4. **[Q]** Is Neutron an active/standy HA? I got this understanding from the docs
+4. **[Q]** Is Neutron an active/standby HA? I got this understanding from the docs
    and I want to understand why. I was told that Grizzly and Havanna support multiple
    L3 agents but Mirantis OpenStack only supports a single L3 agent.
 

--- a/pages/operations/2360-config-operating-system-node.rst
+++ b/pages/operations/2360-config-operating-system-node.rst
@@ -22,7 +22,7 @@ Some general administrative tasks you may need to perform are:
   and populate the *fstab* file so they will mount automatically.
 - Configure additional :ref:`logical networks<logical-networks-arch>`
   you need; Fuel only configures the Admin/PXE network.
-- Set up any monitoring facilites you want to use
+- Set up any monitoring facilities you want to use
   such as **monit** and **atop**;
   configure **syslog** to send error messages to a centralized syslog server.
 - Tune kernel resources to optimize performance for the particular applications

--- a/pages/operations/2451-rabbitmq-backport-ocf.rst
+++ b/pages/operations/2451-rabbitmq-backport-ocf.rst
@@ -160,7 +160,7 @@ script are not applicable for them.
      - Add the parameter ``command_timeout`` with the value ``--signal=KILL``
 
        .. note:: The ``command_timeout`` parameter value is given for Ubuntu OS.
-          For Centos, this parameter should be set to a ``-s KILL``
+          For CentOS, this parameter should be set to a ``-s KILL``
 
 
        Use ``some_param="some_value"`` notation, or for the XML case:

--- a/pages/operations/2455-manage-openstack-services.rst
+++ b/pages/operations/2455-manage-openstack-services.rst
@@ -49,7 +49,7 @@ HowTo: Manage OpenStack services
 
    Next, you should inspect the output of command ``pcs resource``
    (or ``crm resource list``) and find the corresponding services listed, if any.
-   For example, if the 2nd chkconfig command reported on Centos OS:
+   For example, if the 2nd chkconfig command reported on CentOS:
 
    ::
 

--- a/pages/operations/2510-ceph-osd-placement-groups.rst
+++ b/pages/operations/2510-ceph-osd-placement-groups.rst
@@ -5,7 +5,7 @@ How To: Adjust Placement Groups when adding additional Ceph OSD node(s)
 =======================================================================
 
 When adding additional Ceph OSD nodes to an environment, it may be
-necessary to addjust the placement groups (pg_num) and the placement
+necessary to adjust the placement groups (pg_num) and the placement
 groups for placement (pgp_num) for the pools. The following process
 can be used to update these two values for the Ceph cluster.
 These adjustments may not be necessary unless you add a significant

--- a/pages/operations/backport-ocf.rst
+++ b/pages/operations/backport-ocf.rst
@@ -3,7 +3,7 @@
 HowTo: Backport Galera Pacemaker OCF script
 -------------------------------------------
 
-Fuel 5.1 has completely redesigned OCF script which makes Galera cluster more reliable and predictible
+Fuel 5.1 has completely redesigned OCF script which makes Galera cluster more reliable and predictable
 
 .. note:: Schedule the maintenance window, Perform backups of all databases, Stop MySQL related services before any operations with Galera
 

--- a/pages/operations/docker-on-master.rst
+++ b/pages/operations/docker-on-master.rst
@@ -126,7 +126,7 @@ Stop and destroy a container:
 
 .. note:: This is not reversible, so use with caution.
 
-Find containets names by running:
+Find containers names by running:
 ::
 
   dockerctl list

--- a/pages/operations/how-to-shutdown-cluster-ops.rst
+++ b/pages/operations/how-to-shutdown-cluster-ops.rst
@@ -51,6 +51,6 @@ so the following sequence is possible:
 #. Wait several minutes and check the cluster state with *crm status* command.
    All Neutron agents including L3 and DHCP should be started.
 
-#. Restart all Openstack services.
+#. Restart all OpenStack services.
 
 #. Power on compute nodes.

--- a/pages/operations/patch/0020-identify-files.rst
+++ b/pages/operations/patch/0020-identify-files.rst
@@ -8,7 +8,7 @@ Identify files to be patched
 Identifying files or components to be patched usually involves investigating
 change logs for new OpenStack releases or git commit messages. You can find
 change logs using `OpenStack wiki search <https://wiki.openstack.org/wiki/Special:Search/ReleaseNotes>`_.
-Git commit messages are available from github.com or, in a more accesible form,
+Git commit messages are available from github.com or, in a more accessible form,
 on git.openstack.org. You will need to find the exact commit providing the fix
 for your problem.
 

--- a/pages/operations/patch/0050-apply-patch.rst
+++ b/pages/operations/patch/0050-apply-patch.rst
@@ -10,7 +10,7 @@ corresponds to your operating system. The OpenStack source code
 (.py) files are stored in different locations depending on the
 operating system:
 
-* **Centos**: /usr/lib/python2.6/site-packages/[component] (for example, /usr/lib/python2.6/site-packages/nova)
+* **CentOS**: /usr/lib/python2.6/site-packages/[component] (for example, /usr/lib/python2.6/site-packages/nova)
 
 * **Ubuntu**: /usr/share/pyshared/[component] (for example, /usr/share/pyshared/nova)
 

--- a/pages/operations/sahara/7700-prepare-to-test.rst
+++ b/pages/operations/sahara/7700-prepare-to-test.rst
@@ -6,7 +6,7 @@ Preparing Sahara for Testing
 
 The Platform Tests that are run as part of the Health Tests
 that test Sahara if it is configured in the Environment.
-Before runing the test,
+Before running the test,
 you must manually perform the actions listed below.
 
 Note that the tests are run in the tenant

--- a/pages/planning-guide/0020-system-requirements/0030-sample-target-config.rst
+++ b/pages/planning-guide/0020-system-requirements/0030-sample-target-config.rst
@@ -44,7 +44,7 @@ Each controller should have:
 - Hardware RAID1 Controller with at least 1TB formatted capacity
   for the Host operating system disk.
   Larger disks may be warranted
-  depending on expected database ang log storage requirements.
+  depending on expected database and log storage requirements.
   Note that it is non-trivial to expand the disk storage
   on running Controller nodes.
 - 2 NICs, either 1 Gbit/s or 10 Gbit/s

--- a/pages/planning-guide/0090-appendix/0097-ex-ha-neutron-vlan.rst
+++ b/pages/planning-guide/0090-appendix/0097-ex-ha-neutron-vlan.rst
@@ -33,19 +33,19 @@ The switches and servers is designed in this example to support five networks as
 **Cloud Networks**
 
 * Admin (PXE) network - 10.142.10.0/24 (no gateway, untagged via the 1GbE switch)
-* Managemenet network  - 192.168.0.0/24 (no gateway, VLAN 3 via Mellanox SX1036 40/56GbE switch)
+* Management network  - 192.168.0.0/24 (no gateway, VLAN 3 via Mellanox SX1036 40/56GbE switch)
 * Storage network     - 192.168.1.0/24 (no gateway, VLAN 4 via Mellanox SX1036 40/56GbE switch)
 * Public network      - 10.7.208.0/24  (gateway 10.7.208.1, untagged via the 1GbE switch)
 * Private network     - <any>          (no gateway, use range of VLANs e.g. 5-15 via Mellanox SX1036 40/56GbE switch)
 
-.. note:: Internet access is acheived via the Public network.
+.. note:: Internet access is achieved via the Public network.
 
 .. note:: All nodes should be connected to all networks (besides the Fuel node).
 
-.. note:: The 1GbE switch configuraiton for the Public and Admin (PXE) networks are similar to examples 1 and 2 above.
+.. note:: The 1GbE switch configuration for the Public and Admin (PXE) networks are similar to examples 1 and 2 above.
 
 
-**Network Configuation**
+**Network Configuration**
 
 * Floating IP range 10.7.208.101-200
 * DNS 8.8.4.4, 8.8.8.8
@@ -55,7 +55,7 @@ From server side (all nodes), ports with following VLAN IDs are used:
 
 *  eth0 - Admin (PXE) - untagged
 *  eth1 - Public - untagged
-*  eth2 (40/56GbE port) - Management VLAN 3, Storage VLAN 4 (+ VLANS 5-15 for the privte networks)
+*  eth2 (40/56GbE port) - Management VLAN 3, Storage VLAN 4 (+ VLANS 5-15 for the private networks)
 
 .. image:: /_images/user_screen_shots/interfaces_example.png
    :align: center

--- a/pages/planning-guide/4450-monitoring.rst
+++ b/pages/planning-guide/4450-monitoring.rst
@@ -5,7 +5,7 @@ Plan Monitoring Facilities
 ==========================
 
 Mirantis OpenStack can deploy two different
-metering and montoring facilities:
+metering and monitoring facilities:
 
 - **Ceilometer** to query and store metering data
   that can be used for billing purposes

--- a/pages/planning-guide/7000-vcenter-plan.rst
+++ b/pages/planning-guide/7000-vcenter-plan.rst
@@ -70,7 +70,7 @@ For more information:
   <http://pubs.vmware.com/vsphere-55/index.jsp#com.vmware.vsphere.install.doc/GUID-7C9A1E23-7FCD-4295-9CB1-C932F2423C63.html>`_.
 
 - See :ref:`Limitations<vcenter-limitations>` section for more details
-  on compatility with other VMware components and Mirantis lab setup.
+  on compatibility with other VMware components and Mirantis lab setup.
 
 
 vSphere Installation

--- a/pages/reference-architecture/network-concepts/6011-ha-networking.rst
+++ b/pages/reference-architecture/network-concepts/6011-ha-networking.rst
@@ -7,7 +7,7 @@ HA deployment for Networking
 
 Fuel leverages
 `Pacemaker resource agents <http://www.linux-ha.org/wiki/Resource_agents>`_
-in order to deploy highly avaiable networking for OpenStack environments.
+in order to deploy highly available networking for OpenStack environments.
 
 Virtual IP addresses deployment details
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +22,7 @@ migrates to another node
 In order to achieve this, resource agent scripts for `ocf:heartbeat:haproxy`
 and `ocf:heartbeat:IPaddr2` were hardened with network namespaces support.
 
-Successfull failover of public VIP address requires controller nodes
+Successful failover of public VIP address requires controller nodes
 to perform active checking of the public gateway. Fuel configures
 the Pacemaker resource `clone_ping_vip__public` that makes public VIP to
 migrate in case the controller can't ping its public gateway.

--- a/pages/reference-architecture/ovs/0230-cli-transformation.rst
+++ b/pages/reference-architecture/ovs/0230-cli-transformation.rst
@@ -51,7 +51,7 @@ Here are the the available options:
                                 # e.g. ['eth1','eth2']
     "bridge": "xxx",            # name of the bridge where the bond should be created
     "tag": 0,                   # [optional; default: 0] a 802.1q tag of traffic which
-                                # should be catched from an OVS bridge;
+                                # should be cached from an OVS bridge;
                                 # possible values: 0 (means port is a trunk),
                                 # 1-4094 (means port is an access)
     "trunks": [],               # [optional; default: []] a set of 802.1q tags

--- a/pages/reference-architecture/task-deployment/0010-task-schema.rst
+++ b/pages/reference-architecture/task-deployment/0010-task-schema.rst
@@ -85,7 +85,7 @@ Skipped
 -------
 
 Making a task ``skipped`` will guarantee that this task will not be executed,
-but all the task's depdendencies will be preserved:
+but all the task's dependencies will be preserved:
 
 .. code-block:: yaml
 
@@ -163,7 +163,7 @@ This task will upload data specified in ``data`` parameters to the
 Sync
 ----
 
-Sync task will distribute files from ``src`` direcory
+Sync task will distribute files from ``src`` directory
 on the Fuel Master node
 to ``dst`` directory on target hosts
 that will be matched by role:

--- a/pages/reference-architecture/task-deployment/0030-faq.rst
+++ b/pages/reference-architecture/task-deployment/0030-faq.rst
@@ -18,7 +18,7 @@ Is it possible to specify cross-dependencies between groups?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In Fuel 6.0 or earlier, there is no model that will allow to run tasks
-on a primary Controller, then run on a controlle with getting back to the
+on a primary Controller, then run on a controller with getting back to the
 primary Controller.
 
 In Fuel 6.1, cross-dependencies are resolved by the ``post_deployment`` stage.

--- a/pages/reference-architecture/task-deployment/0060-add-new-role.rst
+++ b/pages/reference-architecture/task-deployment/0060-add-new-role.rst
@@ -70,7 +70,7 @@ follow these steps:
 
       fuel rel --sync-deployment-tasks --dir /etc/puppet/2014.2-6.1/
 
-#. :ref:`Create an enviroment <create-env-ug>`. Note the following:
+#. :ref:`Create an environment <create-env-ug>`. Note the following:
 
    * :ref:`configure public network <network-settings-ug>`
      properly since *redis* packages are fetched from the upstream.

--- a/pages/release-notes/v3-2-1-grizzly-full.rst
+++ b/pages/release-notes/v3-2-1-grizzly-full.rst
@@ -92,7 +92,7 @@ packages on Ubuntu 12.04 as the host operating system for the OpenStack nodes.
 The Ubuntu 12.04 operating system is included in the ISO for Mirantis 
 OpenStack, so you can select Ubuntu from the Releases window and deploy 
 without requiring Internet access or downloading additional software. This 
-expands your choices for deployment to Centos with Mirantis OpenStack 
+expands your choices for deployment to CentOS with Mirantis OpenStack 
 hardened packages, Red Hat Enterprise Linux with Red Hat OpenStack, or 
 Ubuntu with Mirantis OpenStack hardened packages. 
 

--- a/pages/release-notes/v4-1/050-known-issues.rst
+++ b/pages/release-notes/v4-1/050-known-issues.rst
@@ -78,8 +78,8 @@ with a VLAN splinters workaround enabled in two separate modes -- soft trunks an
    This provides the least amount of performance overhead
    but the traffic may not be passed onto the OVS bridge in some edge cases.
 
-*  The **hard trunks mode** also configureS OVS to enable splinters
-   but useS an explicitly defined list of all VLANs across all interfaces.
+*  The **hard trunks mode** also configures OVS to enable splinters
+   but uses an explicitly defined list of all VLANs across all interfaces.
    This should prevent the occasional failures associated with the soft mode
    but requires that corresponding tags be created on all of the interfaces.
    This introduces additional performance overhead.

--- a/pages/release-notes/v5-1/020-new-features.rst
+++ b/pages/release-notes/v5-1/020-new-features.rst
@@ -101,7 +101,7 @@ See :ref:`experimental-features-term` for more information.
 The Fuel Master Node can now be backed up and restored
 ------------------------------------------------------
 Building on the :ref:`Docker<docker-term>` packaging architecture
-introduced in Mirantis Openstack 5.0,
+introduced in Mirantis OpenStack 5.0,
 the current state of the Fuel Master Node
 can now be backed up and, if necessary, restored.
 This must be done from the command line.

--- a/pages/release-notes/v5-1/038-resolved-ha-issues.rst
+++ b/pages/release-notes/v5-1/038-resolved-ha-issues.rst
@@ -90,7 +90,7 @@ Management network now restarts correctly
 
 The interface state is now checked when restarting
 the Management logical network.
-This solves the problems that sometime occured
+This solves the problems that sometimes occurred
 when br-mgmt (the bridge for the Management logical network
 on the Neutron topology) was shut down from the main Controller node,
 making the Controller cluster unreachable.

--- a/pages/release-notes/v5-1/040-resolved-issues.rst
+++ b/pages/release-notes/v5-1/040-resolved-issues.rst
@@ -168,7 +168,7 @@ See `LP1342073 <https://bugs.launchpad.net/bugs/1342073>`_.
 and `LP1340968 <https://bugs.launchpad.net/bugs/1340968>`_.
 
 
-Openstack services are no longer started as soon as they are installed on Ubuntu systems
+OpenStack services are no longer started as soon as they are installed on Ubuntu systems
 ----------------------------------------------------------------------------------------
 
 Puppet installs the Fuel packages.

--- a/pages/release-notes/v5-1/040-resolved-issues.rst
+++ b/pages/release-notes/v5-1/040-resolved-issues.rst
@@ -73,7 +73,7 @@ are fixed:
 - Second rsyslog server definition no longer breaks logs
   to master. See `LP1339659 <https://bugs.launchpad.net/bugs/1339659>`_.
 
-- Logs are now rotated on bootstraped nodes.
+- Logs are now rotated on bootstrapped nodes.
   See `LP1364083 <https://bugs.launchpad.net/fuel/+bug/1364083>`_.
 
 - Bootstrap node does not die after a week of inactivity.
@@ -361,7 +361,7 @@ In earlier releases,
 using the Fuel CLI to add a new Compute node to an environment
 caused Puppet to run on all nodes in the environment.
 Configuration information is now stored per node rather than per cluster
-so that clusters can be managed seemlessly
+so that clusters can be managed seamlessly
 using either the Fuel UI or the Fuel CLI.
 See `LP1280318 <https://bugs.launchpad.net/fuel/+bug/1280318>`_.
 
@@ -431,7 +431,7 @@ Galera bugs were fixed
   so it does not time out.
   See `LP1354479 <https://bugs.launchpad.net/fuel/+bug/1354479>`_.
 
-* Galera now reassambles on Galera quorum loss.
+* Galera now reassembles on Galera quorum loss.
   See `LP1350545 <https://bugs.launchpad.net/fuel/+bug/1350545>`_.
 
 * Galera changes to config in Puppet manifests now correctly refresh MySQL service.
@@ -854,7 +854,7 @@ Other resolved issues
 * Puppet no longer generates wrong dnsmasq.upstream in Cobbler container.
   See `LP1327799 <https://bugs.launchpad.net/fuel/+bug/1327799>`_.
 
-* OpenStack engine now corretly checks releases for uniqueness.
+* OpenStack engine now correctly checks releases for uniqueness.
   See `LP1327198 <https://bugs.launchpad.net/fuel/+bug/1327198>`_.
 
 * Docker0 interface bug was fixed for PXE.
@@ -869,7 +869,7 @@ Other resolved issues
 * "Stevedore.extension" error no longer occurs.
   See `LP1325519 <https://bugs.launchpad.net/fuel/+bug/1325519>`_.
 
-* UI is not cached between FUel versions.
+* UI is not cached between Fuel versions.
   See `LP1325012 <https://bugs.launchpad.net/fuel/+bug/1325012>`_.
 
 * Production-oriented configuration parameters were set for Nova and Neutron.
@@ -926,7 +926,7 @@ Other resolved issues
 * "MultipleAgentFoundByTypeHost" error was fixed.
   See `LP1322228 <https://bugs.launchpad.net/fuel/+bug/1322228>`_.
 
-* Error in neutron-resheduling log no nolger occurs.
+* Error in neutron-resheduling log no longer occurs.
   See `LP1322221 <https://bugs.launchpad.net/fuel/+bug/1322221>`_.
 
 * After HA FlatDHCP deployment, redundant interfaces do not appear in controller node.
@@ -1136,7 +1136,7 @@ Other resolved issues
 * The syslog logging is not affected by /dev/log race conditions.
   See `LP1342068 <https://bugs.launchpad.net/fuel/+bug/1342068>`_.
 
-* Both cluster and volumes are removed in enrivonment, deployed with Cinder.
+* Both cluster and volumes are removed in environment, deployed with Cinder.
   See `LP1341650 <https://bugs.launchpad.net/fuel/+bug/1341650>`_.
 
 * *URI too long* error was fixed in Neutron security group rule list.

--- a/pages/release-notes/v5-1/050-known-issues.rst
+++ b/pages/release-notes/v5-1/050-known-issues.rst
@@ -106,7 +106,7 @@ but it has some known limitations:
 
 * External network is not configured when changing the ML2 mechanism
   to Mellanox and Open vSwitch.
-  When installing Centos HA with Neutron with VLAN
+  When installing CentOS HA with Neutron with VLAN
   and changing the ML2 mechanism to Mellanox and Open vSwitch,
   the external network is not configured after deployment.
   See `LP1369988 <https://bugs.launchpad.net/bugs/1369988>`_.

--- a/pages/release-notes/v5-1/050-known-issues.rst
+++ b/pages/release-notes/v5-1/050-known-issues.rst
@@ -326,7 +326,7 @@ soft trunks and hard trunks:
    This provides the least amount of performance overhead
    but the traffic may not be passed onto the OVS bridge in some edge cases.
 
-*  The **hard trunks mode** also configureS OVS to enable splinters
+*  The **hard trunks mode** also configures OVS to enable splinters
    but uses an explicitly defined list of all VLANs across all interfaces.
    This should prevent the occasional failures associated with the soft mode
    but requires that corresponding tags be created on all of the interfaces.
@@ -496,7 +496,7 @@ See `LP1370006 <https://bugs.launchpad.net/fuel/+bug/1370006>`_.
 Evacuate fails on Ceph backed volumes
 -------------------------------------
 
-VM instances that use ephermeral drives with Ceph RBD as the backend
+VM instances that use ephemeral drives with Ceph RBD as the backend
 cannot be evacuated using the **nova evacuate** command
 because of an error in the instance rebuild logic.
 To move such instances to another compute node,

--- a/pages/release-notes/v5-1/070-support.rst
+++ b/pages/release-notes/v5-1/070-support.rst
@@ -11,6 +11,6 @@ registered trademarks of Mirantis, Inc. in the U.S. and/or certain other countri
 Ubuntu is a registered trademark of Canonical Ltd.
 VirtualBox is a registered trademark of Oracle Corporation.
 VMware, NSX, vCenter, and ESXi are trademarks or registered trademarks of VMware, Inc.
-Mellanox and ConnectX are reigstered trademarks of Mellanox Technologies.
+Mellanox and ConnectX are registered trademarks of Mellanox Technologies.
 All other registered trademarks or trademarks belong to their respective companies.
 Copyright 2014 Mirantis, Inc. All rights reserved.

--- a/pages/release-notes/v6-0/0070-support.rst
+++ b/pages/release-notes/v6-0/0070-support.rst
@@ -11,6 +11,6 @@ registered trademarks of Mirantis, Inc. in the U.S. and/or certain other countri
 Ubuntu is a registered trademark of Canonical Ltd.
 VirtualBox is a registered trademark of Oracle Corporation.
 VMware, NSX, vCenter, and ESXi are trademarks or registered trademarks of VMware, Inc.
-Mellanox and ConnectX are reigstered trademarks of Mellanox Technologies.
+Mellanox and ConnectX are registered trademarks of Mellanox Technologies.
 All other registered trademarks or trademarks belong to their respective companies.
 Copyright 2014 Mirantis, Inc. All rights reserved.

--- a/pages/release-notes/v6-0/1030-fuel-install.rst
+++ b/pages/release-notes/v6-0/1030-fuel-install.rst
@@ -78,7 +78,7 @@ Fuel default disk partition scheme is sub-optimal
 
 * On target nodes that use Ubuntu as the operating system,
   Ubuntu provisioning applies the default Base System partition
-  even if the user choses a different scheme.
+  even if the user chooses a different scheme.
 
 New node may not boot because of IOMMU issues
 +++++++++++++++++++++++++++++++++++++++++++++

--- a/pages/release-notes/v6-0/1040-hardware.rst
+++ b/pages/release-notes/v6-0/1040-hardware.rst
@@ -12,7 +12,7 @@ New Features and Resolved Issues in Mirantis OpenStack 6.0
   See `LP1270889 <https://bugs.launchpad.net/fuel/+bug/1270889>`_.
 
 
-Known Issues in Mirantis Openstack 6.0
+Known Issues in Mirantis OpenStack 6.0
 --------------------------------------
 
 CentOS issues using Neutron-enabled installations with VLANS

--- a/pages/release-notes/v6-0/new-features/mcn.rst
+++ b/pages/release-notes/v6-0/new-features/mcn.rst
@@ -1,5 +1,5 @@
 
-Mutiple network domains per OpenStack environment
+Multiple network domains per OpenStack environment
 -------------------------------------------------
 
 Multiple network domains can now be used for environments

--- a/pages/release-notes/v6-0/other/6040-murano.rst
+++ b/pages/release-notes/v6-0/other/6040-murano.rst
@@ -17,7 +17,7 @@ New Features and Resolved Issues in Mirantis OpenStack 6.0
 * Murano is now present in the Keystone service list.
   See `LP1362037 <https://bugs.launchpad.net/bugs/1362037>`_.
 
-* RabbitMQ now handles Murano users correnctly
+* RabbitMQ now handles Murano users correctly
   and so no longer loses Murano users
   when the Primary Controller in an HA cluster is shut down.
   See `LP1372483 <https://bugs.launchpad.net/fuel/+bug/1372483>`_.
@@ -41,7 +41,7 @@ Known Issues in Mirantis OpenStack 6.0
 
   #. Log into one of the Controller nodes
      and execute the **source openrc** command
-     to import credentials and access OpenStack servces from the CLI.
+     to import credentials and access OpenStack services from the CLI.
 
   #. Get the service-id for the Murano service:
 

--- a/pages/release-notes/v6-1/0070-support.rst
+++ b/pages/release-notes/v6-1/0070-support.rst
@@ -11,6 +11,6 @@ registered trademarks of Mirantis, Inc. in the U.S. and/or certain other countri
 Ubuntu is a registered trademark of Canonical Ltd.
 VirtualBox is a registered trademark of Oracle Corporation.
 VMware, NSX, vCenter, and ESXi are trademarks or registered trademarks of VMware, Inc.
-Mellanox and ConnectX are reigstered trademarks of Mellanox Technologies.
+Mellanox and ConnectX are registered trademarks of Mellanox Technologies.
 All other registered trademarks or trademarks belong to their respective companies.
 Copyright 2015 Mirantis, Inc. All rights reserved.

--- a/pages/release-notes/v6-1/1090-test.rst
+++ b/pages/release-notes/v6-1/1090-test.rst
@@ -4,7 +4,7 @@
 Test and Verification Issues
 ============================
 
-Resolved test and verifiation issues
+Resolved test and verification issues
 ------------------------------------
 
 Known test and verification issues

--- a/pages/release-notes/v6-1/other/4020-keystone.rst
+++ b/pages/release-notes/v6-1/other/4020-keystone.rst
@@ -4,8 +4,8 @@
 OpenStack Identity (Keystone)
 -----------------------------
 
-Resolved Keyston Issues
-+++++++++++++++++++++++
+Resolved Keystone Issues
+++++++++++++++++++++++++
 
-Known Keyston Issues
-++++++++++++++++++++
+Known Keystone Issues
++++++++++++++++++++++

--- a/pages/style-guide/0901-style-notes-fuel-plugins.rst
+++ b/pages/style-guide/0901-style-notes-fuel-plugins.rst
@@ -46,7 +46,7 @@ Plugin Guide is formed according to the template.
 In fact, it consists of four basic parts:
 
 #. Introductory - what functionality does the plugin have,
-   what technologues are involved, what are the plugin-specific
+   what technologies are involved, what are the plugin-specific
    terms, what are the use cases.
 
 #. Installation - how to perform configuration of additional components (for example,
@@ -137,7 +137,7 @@ Screenshots
 
 #. If your plugin works only in a specific Fuel configuration
    (for instance, with Neutron as a Networking Setup), please
-   provide a screeenshot with the selected option. For example,
+   provide a screenshot with the selected option. For example,
    this plugin works in Neutron with VLAN segmentation setup only.
    To demonstrate this, we should provide the following screenshot:
 

--- a/pages/terminology/g/glance.rst
+++ b/pages/terminology/g/glance.rst
@@ -3,7 +3,7 @@
 Glance
 ------
 Glance is the OpenStack Image Storage project.
-Glance provides a scaleable, RESTful API for VM images and metadata.
+Glance provides a scalable, RESTful API for VM images and metadata.
 
 Fuel can deploy either of the following
 as the storage backend for Glance:

--- a/pages/terminology/j/juno.rst
+++ b/pages/terminology/j/juno.rst
@@ -5,7 +5,7 @@ Juno
 ----
 
 Code name for the tenth release of the OpenStack software.
-Mirantis OpenStack version 6.0 incorporates and supporte
+Mirantis OpenStack version 6.0 incorporates and supports
 the Juno code base.
 The following improvements in Juno are not deployed
 by Fuel 6.x

--- a/pages/terminology/j/juno.rst
+++ b/pages/terminology/j/juno.rst
@@ -4,7 +4,7 @@
 Juno
 ----
 
-Code name for the tenth release of the Openstack software.
+Code name for the tenth release of the OpenStack software.
 Mirantis OpenStack version 6.0 incorporates and supporte
 the Juno code base.
 The following improvements in Juno are not deployed

--- a/pages/terminology/l/lxc.rst
+++ b/pages/terminology/l/lxc.rst
@@ -4,7 +4,7 @@
 LXC (Linux containers)
 ----------------------
 
-LXC (Linux containers) are peacemeal containers
+LXC (Linux containers) are piecemeal containers
 that can be modified, upgraded, and backed up independently.
 LXC is a user space interface to the Linux kernel containment features.
 See `LXC <https://linuxcontainers.org/>`_

--- a/pages/terminology/m/memcached.rst
+++ b/pages/terminology/m/memcached.rst
@@ -14,10 +14,10 @@ and `Key-value stores <http://docs.openstack.org/admin-guide-cloud/content/dashb
 admin guides for details.
 :ref:`Swift<swift-object-storage-term>` proxy server is also
 configured to use the memcached,
-see `Object Storage documentaion <http://docs.openstack.org/admin-guide-cloud/content/object-storage-service.html>`_.
+see `Object Storage documentation <http://docs.openstack.org/admin-guide-cloud/content/object-storage-service.html>`_.
 
 .. note:: Fuel configures the Keystone to use the ``memcache_pool``
-   backend for tokens, but tokens revokations are tracked in the
+   backend for tokens, but tokens revocations are tracked in the
    :ref:`MySQL/Galera<galera-cluster-term>` backend due to
    security reasons. Starting from the Fuel 6.1 release, the
    memcached instances are also configured to consume no more

--- a/pages/terminology/p/pacemaker.rst
+++ b/pages/terminology/p/pacemaker.rst
@@ -4,7 +4,7 @@
 Pacemaker
 ---------
 High-availability resource manager for Linux based clusters.
-Fuel uses Packemaker with :ref:`corosync-term`
+Fuel uses Pacemaker with :ref:`corosync-term`
 to implement :ref:`ha-term` for OpenStack services.
 
 See:

--- a/pages/terminology/v/vlan.rst
+++ b/pages/terminology/v/vlan.rst
@@ -19,7 +19,7 @@ on the management, storage, and public networks.
 
 The version of CentOS that Fuel deploys
 has poor support for VLAN tagged packets
-so work-aronds are provided to improve the VLAN support
+so workarounds are provided to improve the VLAN support
 when using CentOS;
 see :ref:`vlan-splinters-ug`.
 

--- a/pages/terminology/z/zabbix.rst
+++ b/pages/terminology/z/zabbix.rst
@@ -22,7 +22,7 @@ For Release 5.1, Zabbix can monitor the following:
 
 - Core infrastructure components: :ref:`mysql-term`,
   :ref:`rabbitmq-term`, :ref:`haproxy-term`,
-  memchached, and libvirtd.
+  memcached, and libvirtd.
 
 - Operating system statistics: Disk I/O, CPU load, free RAM, et cetera.
 

--- a/pages/user-guide/0800-node-internals.rst
+++ b/pages/user-guide/0800-node-internals.rst
@@ -65,7 +65,7 @@ The meaning of these fields is:
             :provisioned:     Node is provisioned but not deployed
             :deploying:       Node is being deployed
                               (OpenStack is being installed and configured)
-            :error:    Deployment/provisiong of the node has failed
+            :error:    Deployment/provisioning of the node has failed
 
 :name:    Name of the node as displayed on the screen when you
           :ref:`assign roles to nodes<assign-roles-ug>`.

--- a/pages/user-guide/config-environment/settings/3600-mellanox-neutron.rst
+++ b/pages/user-guide/config-environment/settings/3600-mellanox-neutron.rst
@@ -52,5 +52,5 @@ iSER configuration:
 
 **Note:**
 `HowTo Install Mirantis Fuel 5.1 OpenStack with Mellanox Adapters Support <http://community.mellanox.com/docs/DOC-1474/>`_ includes
-advanced information regarding Mirantis Openstack installation over
+advanced information regarding Mirantis OpenStack installation over
 Mellanox hardware.

--- a/pages/user-guide/config-environment/settings/3600-mellanox-neutron.rst
+++ b/pages/user-guide/config-environment/settings/3600-mellanox-neutron.rst
@@ -9,7 +9,7 @@ Mellanox Neutron components
 +++++++++++++++++++++++++++
 
 This section explains how to configure Mellanox ConnectX-3 adapters
-in your environement. See :ref:`mellanox-adapters` for
+in your environment. See :ref:`mellanox-adapters` for
 planning information.
 
 Kernel parameters configuration:

--- a/pages/user-guide/fuel-on-vsphere/5000-create-vm.rst
+++ b/pages/user-guide/fuel-on-vsphere/5000-create-vm.rst
@@ -53,7 +53,7 @@ Select a guest operating system such as RHEL 6 64-bit:
 
 
 Set the memory size to at least 2GB and HDD size at least 50 GB.
-The Fuel Master node hardware recomendations are described here:
+The Fuel Master node hardware recommendations are described here:
 :ref:`HardwarePrerequisites`.
 A network adapter must be connected to the Fuel PXE network
 created above.


### PR DESCRIPTION
Notes:

* The changes to the README just render certain lines as code blocks, in line with the rest of the document.
* I wasn't sure whether it's okay to make changes to release notes for old versions, so I split those out into a separate commit. I can roll them back if necessary.
* The typos were spotted by aspell, and corrected by hand.
* In `0300-other-questions.rst`, I was guessing about what "standy" was meant to be. I tried to get it from the context, but I wasn't completely sure.
* In `pages/terminology/m/ml2.rst:24`, I spotted this line:

    >   Two methods are exposed for each action:

    > - ACTION_RESOUCE__precommit -- called within the context

  I wasn't sure whether "RESOUCE" was a typo in the docs, or whether the method name misspelt in the actual code (and if the latter, should the discrepancy be highlighted in the docs?).